### PR TITLE
hotfix/cp-9899-cleverpush-expo-plugin-installation

### DIFF
--- a/cleverpush/withCleverPushIos.ts
+++ b/cleverpush/withCleverPushIos.ts
@@ -17,6 +17,7 @@ import { CleverPushLog } from "../support/CleverPushLog";
 import { FileManager } from "../support/FileManager";
 import CleverPushNseUpdaterManager from "../support/CleverPushNseUpdaterManager";
 import { updatePodfile } from "../support/updatePodfile";
+import getEasManagedCredentialsConfigExtra from "../support/eas/getEasManagedCredentialsConfigExtra";
 import assert from 'assert';
 
 const withAppEnvironment: ConfigPlugin<CleverPushPluginProps> = (
@@ -148,6 +149,12 @@ const withCleverPushNSE: ConfigPlugin<CleverPushPluginProps> = (config: ExpoConf
   ]);
 };
 
+const withEasManagedCredentials: ConfigPlugin<CleverPushPluginProps> = (config: ExpoConfig, props: CleverPushPluginProps) => {
+  assert(config.ios?.bundleIdentifier, "Missing 'ios.bundleIdentifier' in app config.")
+  config.extra = getEasManagedCredentialsConfigExtra(config as ExpoConfig);
+  return config;
+}
+
 const withCleverPushXcodeProject: ConfigPlugin<CleverPushPluginProps> = (config: ExpoConfig, props: CleverPushPluginProps) => {
   return withXcodeProject(config, (newConfig: any) => {
     try {
@@ -229,7 +236,17 @@ const withCleverPushXcodeProject: ConfigPlugin<CleverPushPluginProps> = (config:
           buildSettingsObj.TARGETED_DEVICE_FAMILY = TARGETED_DEVICE_FAMILY;
           buildSettingsObj.CODE_SIGN_ENTITLEMENTS = `${NSE_TARGET_NAME}/${NSE_TARGET_NAME}.entitlements`;
           buildSettingsObj.CODE_SIGN_STYLE = "Automatic";
+          
+          if (props?.devTeam) {
+            buildSettingsObj.DEVELOPMENT_TEAM = props.devTeam;
+          }
         }
+      }
+      
+  
+      if (props?.devTeam) {
+        xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam, nseTarget);
+        xcodeProject.addTargetAttribute("DevelopmentTeam", props.devTeam);
       }
       
       CleverPushLog.log(`[CleverPush] Xcode project configuration completed successfully`);
@@ -256,6 +273,7 @@ export const withCleverPushIos: ConfigPlugin<CleverPushPluginProps> = (
   config = withCleverPushPodfile(config, props);
   config = withCleverPushNSE(config, props);
   config = withCleverPushXcodeProject(config, props);
+  config = withEasManagedCredentials(config, props);
   
   CleverPushLog.log(`[CleverPush] iOS configuration completed successfully`);
   return config;

--- a/support/eas/getEasManagedCredentialsConfigExtra.ts
+++ b/support/eas/getEasManagedCredentialsConfigExtra.ts
@@ -1,0 +1,35 @@
+import { NSE_TARGET_NAME } from "../iosConstants";
+import { ExpoConfig } from '@expo/config-types';
+
+export default function getEasManagedCredentialsConfigExtra(config: ExpoConfig): {[k: string]: any} {
+  return {
+    ...config.extra,
+    eas: {
+      ...config.extra?.eas,
+      build: {
+        ...config.extra?.eas?.build,
+        experimental: {
+          ...config.extra?.eas?.build?.experimental,
+          ios: {
+            ...config.extra?.eas?.build?.experimental?.ios,
+            appExtensions: [
+              ...(config.extra?.eas?.build?.experimental?.ios?.appExtensions ?? []),
+              {
+                targetName: NSE_TARGET_NAME,
+                bundleIdentifier: `${config?.ios?.bundleIdentifier}.${NSE_TARGET_NAME}`,
+                entitlements: {
+                  'com.apple.security.application-groups': [
+                    `group.${config?.ios?.bundleIdentifier}.cleverpush`
+                  ]
+                },
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+
+
+

--- a/types/types.ts
+++ b/types/types.ts
@@ -1,9 +1,11 @@
 export type CleverPushPluginProps = {
   mode: Mode;
+  devTeam?: string;
 };
 
 export type Mode = "development" | "production";
 
 export const CLEVERPUSH_PLUGIN_PROPS = [
-  "mode"
+  "mode",
+  "devTeam"
 ]; 


### PR DESCRIPTION
Resolved the iOS build issue with the use of EAS.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes iOS EAS builds for the CleverPush Expo plugin by registering the Notification Service Extension (NSE) and configuring signing. Addresses Linear CP-9899 by ensuring EAS managed credentials handle the NSE and entitlements.

- **Bug Fixes**
  - Added withEasManagedCredentials to inject eas.build.experimental.ios.appExtensions at build time.
  - Registers the NSE with a derived bundle identifier and App Group entitlement (group.<bundle>.cleverpush).
  - Applies DevelopmentTeam when devTeam is provided, for both app and NSE targets; keeps Automatic signing and entitlements path.
  - Extends plugin types to include optional devTeam.

<!-- End of auto-generated description by cubic. -->

